### PR TITLE
Add pymanoid.toolbox to the install package list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from distutils.core import setup
 
-setup(name='pymanoid', version='0.4.2', packages=['pymanoid'])
+setup(name='pymanoid', version='0.4.2', packages=['pymanoid', 'pymanoid.toolbox'])


### PR DESCRIPTION
Hello,
As the title says, setup.py does not install subpackages by default. Thus importing pymanoid after a fresh install results in:

``` python
ImportError: No module named toolbox
```

I simply added pymanoid.toolbox to the list of packages to be installed and now the examples are running.

Have a good day!
